### PR TITLE
Added ssl, id, source, include flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,42 @@
 # estail
 
-Try:
+estail is tailing tool for Elasticsearch
+
+## Install
+
+To install `estail`, run below command
 
 ```
-go get github.com/lytics/estail
-estail -h
+go get -u github.com/lytics/estail
 ```
+
+## Usage
+
+```
+$ estail -h
+
+Usage of estail:
+  -exclude string
+        comma separated list of field:value pairs to exclude
+  -host string
+        host and port of elasticsearch (default "localhost:9200")
+  -id
+        show _id field
+  -include string
+        comma separated list of field:value pairs to include
+  -message value
+        message fields to display
+  -poll int
+        time in seconds to poll for new data from ES (default 1)
+  -prefix string
+        prefix of log indexes (default "logstash-")
+  -size int
+        number of docs to return per polling interval (default 1000)
+  -source
+        use _source field to output result
+  -ssl
+        use https for URI scheme
+  -timestamp string
+        timestap field to sort by (default "@timestamp")
+```
+

--- a/estail.go
+++ b/estail.go
@@ -64,14 +64,17 @@ func main() {
 	}
 
 	exFilter := map[string]interface{}{}
-	if len(include) > 0 {
-		exFilter["bool"] = map[string]interface{}{"must": getTerms(include)}
-	}
-	if len(exclude) > 0 {
-		exFilter["not"] = map[string]interface{}{"or": getTerms(exclude)}
-	}
-	if len(exFilter) == 0 {
+	if len(include) == 0 && len(exclude) == 0 {
 		exFilter["match_all"] = map[string]interface{}{}
+	} else {
+		filter := map[string]interface{}{}
+		if len(include) > 0 {
+			filter["must"] = getTerms(include)
+		}
+		if len(exclude) > 0 {
+			filter["must_not"] = getTerms(exclude)
+		}
+		exFilter["bool"] = filter
 	}
 
 	lastTime := time.Now()


### PR DESCRIPTION
This PR contains four important changes,
- 1. HTTPS support
  - use flag `estail -ssl`
- 2. Show `_id` field
  - use flag `estail -id`
- 3. Use the `_source` field instead of the `fileds` filed
  - use flag `estail -source`
- 4. Filtered by key-pair list 
  - use flag `estail -include="@log_level:debug,@log_level:info"`
  - (opposite of `exclude` flag)

sorry for mixing many changes... :sweat: 
